### PR TITLE
[AF-467] Add subscription endpoint for topics

### DIFF
--- a/back/src/main/java/com/openclassrooms/mddapi/controllers/TopicController.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/controllers/TopicController.java
@@ -10,7 +10,9 @@ import com.openclassrooms.mddapi.mappers.TopicMapper;
 import com.openclassrooms.mddapi.models.Topic;
 import com.openclassrooms.mddapi.services.TopicService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
@@ -36,4 +38,22 @@ public class TopicController {
         return ResponseEntity.ok().body(this.topicMapper.toDto(topics));
     }
 
+    /**
+     * Endpoint to subscribe a user to a topic.
+     *
+     * @param id     The ID of the topic to subscribe to.
+     * @param userId The ID of the user who wants to subscribe.
+     * @return ResponseEntity indicating the result of the subscription operation.
+     *         Returns 200 OK if the subscription is successful.
+     *         Returns 400 Bad Request if the provided IDs are not valid numbers.
+     */
+    @PostMapping("{id}/subscribe/{userId}")
+    public ResponseEntity<?> subscribe(@PathVariable("id") String id, @PathVariable("userId") String userId) {
+        try {
+            this.topicService.subscribe(Long.parseLong(id), Long.parseLong(userId));
+            return ResponseEntity.ok().build();
+        } catch (NumberFormatException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/services/TopicService.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/services/TopicService.java
@@ -2,10 +2,14 @@ package com.openclassrooms.mddapi.services;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.openclassrooms.mddapi.exception.NoEntryFoundException;
 import com.openclassrooms.mddapi.models.Topic;
+import com.openclassrooms.mddapi.models.User;
 import com.openclassrooms.mddapi.repository.TopicRepository;
+import com.openclassrooms.mddapi.repository.UserRepository;
 
 /**
  * Service for Topic treatment. Handle get topics actions
@@ -14,9 +18,11 @@ import com.openclassrooms.mddapi.repository.TopicRepository;
 public class TopicService {
 
     private final TopicRepository topicRepository;
+    private final UserRepository userRepository;
 
-    TopicService(TopicRepository topicRepository) {
+    TopicService(TopicRepository topicRepository, UserRepository userRepository) {
         this.topicRepository = topicRepository;
+        this.userRepository = userRepository;
     }
 
     /**
@@ -28,8 +34,35 @@ public class TopicService {
         return this.topicRepository.findAll();
     }
 
+    /**
+     * Retrieve a topic by its id
+     * 
+     * @param id the id of the topic to retrieve
+     * @return the topic with the given id
+     */
     public Topic findById(Long id) {
         return this.topicRepository.findById(id).orElse(null);
     }
 
+    /**
+     * Subscribes a user to a topic.
+     *
+     * @param topicId the ID of the topic to subscribe to
+     * @param userId  the ID of the user who wants to subscribe
+     * @throws NoEntryFoundException if the topic or user is not found
+     */
+    public void subscribe(Long topicId, Long userId) {
+        Topic topic = this.topicRepository.findById(topicId).orElse(null);
+        User user = this.userRepository.findById(userId).orElse(null);
+        if (topic == null || user == null) {
+            throw new NoEntryFoundException("User or topic not found");
+        }
+
+        if (user.getSubscriptions().contains(topic)) {
+            return;
+        }
+
+        user.getSubscriptions().add(topic);
+        this.userRepository.save(user);
+    }
 }


### PR DESCRIPTION
Implement a new endpoint to allow users to subscribe to topics, along with the necessary service logic to handle subscriptions. This includes validation for user and topic existence.