### PR TITLE
[AF-468] Add subscription tests and update data.sql for subscriptions

### DIFF
--- a/back/src/test/java/com/openclassrooms/mddapi/controllers/TopicControllerIT.java
+++ b/back/src/test/java/com/openclassrooms/mddapi/controllers/TopicControllerIT.java
@@ -1,6 +1,7 @@
 package com.openclassrooms.mddapi.controllers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -38,4 +39,19 @@ public class TopicControllerIT {
                 .andExpect(jsonPath("$.length()").value(3));
     }
 
+    @Test
+    public void testSubscribe() throws Exception {
+        // Act and Assert
+        this.mockMvc.perform(post("/api/topic/1/subscribe/2")
+                .with(user("DevAlice")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testSubscribeWithInvalidIds() throws Exception {
+        // Act and Assert
+        this.mockMvc.perform(post("/api/topic/1/subscribe/invalid")
+                .with(user("DevAlice")))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/back/src/test/java/com/openclassrooms/mddapi/controllers/UserControllerIT.java
+++ b/back/src/test/java/com/openclassrooms/mddapi/controllers/UserControllerIT.java
@@ -15,7 +15,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openclassrooms.mddapi.MddApiApplication;
 import com.openclassrooms.mddapi.dto.UserDto;

--- a/back/src/test/java/com/openclassrooms/mddapi/services/TopicServiceTest.java
+++ b/back/src/test/java/com/openclassrooms/mddapi/services/TopicServiceTest.java
@@ -3,6 +3,7 @@ package com.openclassrooms.mddapi.services;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -18,11 +19,21 @@ import com.openclassrooms.mddapi.dto.TopicDto;
 import com.openclassrooms.mddapi.models.Topic;
 import com.openclassrooms.mddapi.repository.TopicRepository;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import java.util.Optional;
+import com.openclassrooms.mddapi.exception.NoEntryFoundException;
+import com.openclassrooms.mddapi.models.User;
+import com.openclassrooms.mddapi.repository.UserRepository;
+
 @ExtendWith(MockitoExtension.class)
 public class TopicServiceTest {
 
     @Mock
     private TopicRepository topicRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private TopicService topicService;
@@ -30,12 +41,22 @@ public class TopicServiceTest {
     private Topic mockTopic;
     private TopicDto mockTopicDto;
 
+    private User mockUser;
+
     @BeforeEach
     public void beforeEach() {
         mockTopic = Topic.builder()
                 .id(1L)
                 .title("Test Topic")
                 .description("This is a test topic")
+                .build();
+
+        mockUser = User.builder()
+                .id(1L)
+                .userName("test")
+                .email("test@email.com")
+                .password("password")
+                .subscriptions(new ArrayList<>())
                 .build();
 
         mockTopicDto = new TopicDto();
@@ -57,4 +78,51 @@ public class TopicServiceTest {
         verify(topicRepository).findAll();
     }
 
+    @Test
+    public void testSubscribe_UserAndTopicExist() {
+        // Arrange
+        Long topicId = 1L;
+        Long userId = 1L;
+        when(topicRepository.findById(topicId)).thenReturn(Optional.of(mockTopic));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        // Act
+        topicService.subscribe(topicId, userId);
+
+        // Assert
+        assertThat(mockUser.getSubscriptions()).contains(mockTopic);
+        verify(userRepository).save(mockUser);
+    }
+
+    @Test
+    public void testSubscribe_UserOrTopicNotFound() {
+        // Arrange
+        Long topicId = 1L;
+        Long userId = 1L;
+        when(topicRepository.findById(topicId)).thenReturn(Optional.empty());
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThatThrownBy(() -> topicService.subscribe(topicId, userId))
+                .isInstanceOf(NoEntryFoundException.class)
+                .hasMessage("User or topic not found");
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    public void testSubscribe_UserAlreadySubscribed() {
+        // Arrange
+        Long topicId = 1L;
+        Long userId = 1L;
+        mockUser.getSubscriptions().add(mockTopic);
+        when(topicRepository.findById(topicId)).thenReturn(Optional.of(mockTopic));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        // Act
+        topicService.subscribe(topicId, userId);
+
+        // Assert
+        assertThat(mockUser.getSubscriptions()).contains(mockTopic);
+        verify(userRepository, never()).save(mockUser);
+    }
 }

--- a/back/src/test/resources/data.sql
+++ b/back/src/test/resources/data.sql
@@ -27,12 +27,12 @@ VALUES
 -- (3, 3, 'Assurez-vous d\'utiliser des multi-stage builds.'); -- DevCharlie commente sur son propre post
 
 -- -- Insertion des abonnements
--- INSERT INTO SUBSCRIPTIONS (user_id, topic_id)
--- VALUES
--- (1, 1), -- DevAlice s'abonne au topic Java Best Practices
--- (2, 2), -- DevBob s'abonne au topic Frontend Frameworks
--- (3, 3), -- DevCharlie s'abonne au topic DevOps Tools
--- (1, 3); -- DevAlice s'abonne également au topic DevOps Tools
+INSERT INTO SUBSCRIPTIONS (user_id, topic_id)
+VALUES
+(1, 1), -- DevAlice s'abonne au topic Java Best Practices
+(2, 2), -- DevBob s'abonne au topic Frontend Frameworks
+(3, 3), -- DevCharlie s'abonne au topic DevOps Tools
+(1, 3); -- DevAlice s'abonne également au topic DevOps Tools
 
 -- -- Insertion dans les feeds
 -- INSERT INTO FEEDS (user_id, post_id)


### PR DESCRIPTION
Introduce tests for subscribing to topics and handle various scenarios, including user and topic existence checks. Update the database initialization script to reflect the current subscription data.