### PR TITLE
[AF-470] feat (FRONT topics) : Add end-to-end tests for topic subscription

### DIFF
--- a/front/cypress/e2e/feed/topics.cy.ts
+++ b/front/cypress/e2e/feed/topics.cy.ts
@@ -30,4 +30,16 @@ describe('Topics List Page', () => {
       );
     cy.get('mat-card-actions button').eq(2).should('not.be.disabled');
   });
+
+  it('should subscribe to a new topic if possible', () => {
+    cy.get('mat-card-actions button').eq(2).click();
+    cy.wait('@subscribe').then((interception) => {
+      expect(interception.response?.statusCode).to.equal(200);
+    });
+    cy.get('snack-bar-container').should(
+      'contain.text',
+      'Vous êtes désormais abonné au thème "React".'
+    );
+    cy.get('mat-card-actions button').eq(2).should('be.disabled');
+  });
 });

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -14,6 +14,11 @@ Cypress.Commands.add('initIntercepts', () => {
   //get all
   cy.interceptWithFixture('GET', '/api/topic', 'topics');
 
+  // user subscribe to topic
+  cy.intercept('POST', '/api/topic/*/subscribe/*', {
+    statusCode: 200,
+  }).as('subscribe');
+
   // register response success
   cy.intercept('POST', '/api/auth/register', {
     body: {


### PR DESCRIPTION
Implement end-to-end tests to verify the functionality of subscribing to topics, ensuring proper response handling and UI updates.