### PR TITLE
[AF-474] Remove unused import and add integration test for user topic subscriptions

### DIFF
--- a/back/src/main/java/com/openclassrooms/mddapi/services/TopicService.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/services/TopicService.java
@@ -2,7 +2,6 @@ package com.openclassrooms.mddapi.services;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.openclassrooms.mddapi.exception.NoEntryFoundException;

--- a/back/src/test/java/com/openclassrooms/mddapi/controllers/UserControllerIT.java
+++ b/back/src/test/java/com/openclassrooms/mddapi/controllers/UserControllerIT.java
@@ -114,4 +114,14 @@ public class UserControllerIT {
 
     }
 
+    @Test
+    public void testGetSubscriptions() throws Exception {
+        // Act and Assert
+        this.mockMvc.perform(get("/api/user/{id}/topics", 1)
+                .with(user("DevAlice")))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+
 }


### PR DESCRIPTION
Eliminate an unused import in the topics service and introduce an integration test to verify user topic subscriptions.