### PR TITLE
[AF-477] feat (BACK topics) : Add unsubscribe functionality for users from topics

### DIFF
--- a/back/src/main/java/com/openclassrooms/mddapi/controllers/TopicController.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/controllers/TopicController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.openclassrooms.mddapi.mappers.TopicMapper;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
@@ -56,4 +59,24 @@ public class TopicController {
             return ResponseEntity.badRequest().build();
         }
     }
+
+    /**
+     * Unsubscribes a user from a topic.
+     *
+     * @param id     the ID of the topic to unsubscribe from
+     * @param userId the ID of the user to unsubscribe
+     * @return a ResponseEntity indicating the result of the operation
+     *         Returns 200 OK if the unsubscribe is successful.
+     *         Returns 400 Bad Request if the provided IDs are not valid numbers.
+     */
+    @DeleteMapping("{id}/unsubscribe/{userId}")
+    public ResponseEntity<?> unsubscribe(@PathVariable("id") String id, @PathVariable("userId") String userId) {
+        try {
+            this.topicService.unsubscribe(Long.parseLong(id), Long.parseLong(userId));
+            return ResponseEntity.ok().build();
+        } catch (NumberFormatException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/services/TopicService.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/services/TopicService.java
@@ -64,4 +64,27 @@ public class TopicService {
         user.getSubscriptions().add(topic);
         this.userRepository.save(user);
     }
+
+    /**
+     * Unsubscribes a user to a topic.
+     *
+     * @param topicId the ID of the topic to unsubscribe to
+     * @param userId  the ID of the user who wants to unsubscribe
+     * @throws NoEntryFoundException if the topic or user is not found
+     */
+    public void unsubscribe(Long topicId, Long userId) {
+        Topic topic = this.topicRepository.findById(topicId).orElse(null);
+        User user = this.userRepository.findById(userId).orElse(null);
+        if (topic == null || user == null) {
+            throw new NoEntryFoundException("User or topic not found");
+        }
+
+        if (!user.getSubscriptions().contains(topic)) {
+            return;
+        }
+
+        user.getSubscriptions().remove(topic);
+        this.userRepository.save(user);
+
+    }
 }

--- a/back/src/test/java/com/openclassrooms/mddapi/controllers/TopicControllerIT.java
+++ b/back/src/test/java/com/openclassrooms/mddapi/controllers/TopicControllerIT.java
@@ -2,6 +2,7 @@ package com.openclassrooms.mddapi.controllers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -48,10 +49,45 @@ public class TopicControllerIT {
     }
 
     @Test
+    public void testSubscribeWithIdNotFound() throws Exception {
+        // Act and Assert
+        this.mockMvc.perform(post("/api/topic/15/subscribe/2")
+                .with(user("DevAlice")))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
     public void testSubscribeWithInvalidIds() throws Exception {
         // Act and Assert
         this.mockMvc.perform(post("/api/topic/1/subscribe/invalid")
                 .with(user("DevAlice")))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testUnsubscribe() throws Exception {
+        // Act and Assert
+        this.mockMvc.perform(delete("/api/topic/3/unsubscribe/2")
+                .with(user("DevAlice")))
+                .andExpect(status().isOk());
+        ;
+    }
+
+    @Test
+    public void testUnsubscribeWithIfNotFound() throws Exception {
+        // Act and Assert
+        this.mockMvc.perform(delete("/api/topic/3/unsubscribe/36")
+                .with(user("DevAlice")))
+                .andExpect(status().isNotFound());
+        ;
+    }
+
+    @Test
+    public void testUnsubscribeWithInvalidIds() throws Exception {
+        // Act and Assert
+        this.mockMvc.perform(delete("/api/topic/invalid/unsubscribe/2")
+                .with(user("DevAlice")))
+                .andExpect(status().isBadRequest());
+        ;
     }
 }

--- a/back/src/test/java/com/openclassrooms/mddapi/services/TopicServiceTest.java
+++ b/back/src/test/java/com/openclassrooms/mddapi/services/TopicServiceTest.java
@@ -125,4 +125,52 @@ public class TopicServiceTest {
         assertThat(mockUser.getSubscriptions()).contains(mockTopic);
         verify(userRepository, never()).save(mockUser);
     }
+
+    @Test
+    public void testUnsubscribe_UserAndTopicExist() {
+        // Arrange
+        Long topicId = 1L;
+        Long userId = 1L;
+        mockUser.getSubscriptions().add(mockTopic);
+        when(topicRepository.findById(topicId)).thenReturn(Optional.of(mockTopic));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        // Act
+        topicService.unsubscribe(topicId, userId);
+
+        // Assert
+        assertThat(mockUser.getSubscriptions()).doesNotContain(mockTopic);
+        verify(userRepository).save(mockUser);
+    }
+
+    @Test
+    public void testUnsubscribe_UserOrTopicNotFound() {
+        // Arrange
+        Long topicId = 1L;
+        Long userId = 1L;
+        when(topicRepository.findById(topicId)).thenReturn(Optional.empty());
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThatThrownBy(() -> topicService.unsubscribe(topicId, userId))
+                .isInstanceOf(NoEntryFoundException.class)
+                .hasMessage("User or topic not found");
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    public void testUnsubscribe_UserNotSubscribed() {
+        // Arrange
+        Long topicId = 1L;
+        Long userId = 1L;
+        when(topicRepository.findById(topicId)).thenReturn(Optional.of(mockTopic));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        // Act
+        topicService.unsubscribe(topicId, userId);
+
+        // Assert
+        assertThat(mockUser.getSubscriptions()).doesNotContain(mockTopic);
+        verify(userRepository, never()).save(mockUser);
+    }
 }


### PR DESCRIPTION
Implement unsubscribe feature in the TopicController and TopicService, along with corresponding tests to ensure functionality and error handling.