### PR TITLE
[AF-487] feat (posts) : Add user feed functionality for subscribed posts

### DIFF
--- a/back/src/main/java/com/openclassrooms/mddapi/controllers/PostController.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/controllers/PostController.java
@@ -1,5 +1,6 @@
 package com.openclassrooms.mddapi.controllers;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +11,7 @@ import com.openclassrooms.mddapi.dto.PostDto;
 import com.openclassrooms.mddapi.mappers.PostMapper;
 import com.openclassrooms.mddapi.models.Post;
 import com.openclassrooms.mddapi.services.PostService;
+import com.openclassrooms.mddapi.services.UserService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,10 +26,12 @@ public class PostController {
 
     private final PostService postService;
     private final PostMapper postMapper;
+    private final UserService userService;
 
-    public PostController(PostService postService, PostMapper postMapper) {
+    public PostController(PostService postService, PostMapper postMapper, UserService userService) {
         this.postService = postService;
         this.postMapper = postMapper;
+        this.userService = userService;
     }
 
     /**
@@ -40,10 +44,11 @@ public class PostController {
     @PostMapping
     @ResponseBody
     public ResponseEntity<?> create(@RequestBody PostDto postDto) {
-        log.info("PostDTO : " + postDto);
         Post post = this.postMapper.toEntity(postDto);
-        log.info(" Post : " + post);
-        return ResponseEntity.ok().body(this.postMapper.toDto(this.postService.save(post)));
+        Post savedPost = this.postService.save(post);
+        // Add the post to the feeds of all users who have subscribed to the topic
+        this.userService.addPostToFeeds(savedPost);
+        return ResponseEntity.ok().body(this.postMapper.toDto(savedPost));
     }
 
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/dto/UserDto.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/dto/UserDto.java
@@ -30,7 +30,11 @@ public class UserDto {
     @Size(max = 120)
     private String password;
 
+    @JsonIgnore
     private List<Long> subscriptions;
+
+    @JsonIgnore
+    private List<Long> feed;
 
     private LocalDateTime createdAt;
 

--- a/back/src/main/java/com/openclassrooms/mddapi/mappers/UserMapper.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/mappers/UserMapper.java
@@ -11,13 +11,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.openclassrooms.mddapi.dto.UserDto;
+import com.openclassrooms.mddapi.models.Post;
 import com.openclassrooms.mddapi.models.Topic;
 import com.openclassrooms.mddapi.models.User;
+import com.openclassrooms.mddapi.services.PostService;
 import com.openclassrooms.mddapi.services.TopicService;
 
 @Component
-@Mapper(componentModel = "spring", uses = { TopicService.class }, imports = { Arrays.class, Collectors.class,
-        Topic.class, User.class, Collections.class, Optional.class })
+@Mapper(componentModel = "spring", uses = { TopicService.class, PostService.class }, imports = { Arrays.class,
+        Collectors.class,
+        Topic.class, Post.class, User.class, Collections.class, Optional.class })
 public abstract class UserMapper implements EntityMapper<UserDto, User> {
 
     @Autowired
@@ -25,10 +28,12 @@ public abstract class UserMapper implements EntityMapper<UserDto, User> {
 
     @Override
     @Mapping(target = "subscriptions", expression = "java(Optional.ofNullable(user.getSubscriptions()).orElseGet(Collections::emptyList).stream().map(t -> t.getId()).collect(Collectors.toList()))")
+    @Mapping(target = "feed", expression = "java(Optional.ofNullable(user.getFeed()).orElseGet(Collections::emptyList).stream().map(p -> p.getId()).collect(Collectors.toList()))")
     public abstract UserDto toDto(User user);
 
     @Override
     @Mapping(target = "subscriptions", expression = "java(Optional.ofNullable(userDto.getSubscriptions()).orElseGet(Collections::emptyList).stream().map(topic_id -> { Topic topic = this.topicService.findById(topic_id); if (topic != null) { return topic; } return null; }).collect(Collectors.toList()))")
+    @Mapping(target = "feed", expression = "java(Optional.ofNullable(userDto.getFeed()).orElseGet(Collections::emptyList).stream().map(post_id -> { Post post = this.postService.findById(post_id); if (post != null) { return post; } return null; }).collect(Collectors.toList()))")
     public abstract User toEntity(UserDto userDto);
 
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/models/User.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/models/User.java
@@ -58,6 +58,11 @@ public class User {
     @JoinTable(name = "SUBSCRIPTIONS", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "topic_id"))
     private List<Topic> subscriptions;
 
+    /** List of post for user feed */
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(name = "FEEDS", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "post_id"))
+    private List<Post> feed;
+
     /** Timestamp of creation, set once and not updatable. */
     @CreatedDate
     @Column(name = "created_at", updatable = false, nullable = false)

--- a/back/src/main/java/com/openclassrooms/mddapi/repository/UserRepository.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/repository/UserRepository.java
@@ -1,10 +1,12 @@
 package com.openclassrooms.mddapi.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.openclassrooms.mddapi.models.Topic;
 import com.openclassrooms.mddapi.models.User;
 
 @Repository
@@ -16,4 +18,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     public Boolean existsByEmail(String email);
 
     public Boolean existsByUserName(String userName);
+
+    public List<User> findBySubscribedTopicsContaining(Topic topic);
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/services/PostService.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/services/PostService.java
@@ -28,5 +28,4 @@ public class PostService {
         log.info("Post saved");
         return post;
     }
-
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/services/UserService.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/services/UserService.java
@@ -1,12 +1,14 @@
 package com.openclassrooms.mddapi.services;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 
 import com.openclassrooms.mddapi.dto.UserDto;
 import com.openclassrooms.mddapi.exception.DuplicateEntryException;
 import com.openclassrooms.mddapi.exception.NoEntryFoundException;
+import com.openclassrooms.mddapi.models.Post;
 import com.openclassrooms.mddapi.models.User;
 import com.openclassrooms.mddapi.repository.UserRepository;
 
@@ -64,6 +66,20 @@ public class UserService {
         userToUpdate.setUpdatedAt(LocalDateTime.now());
 
         return userRepository.save(userToUpdate);
+    }
+
+    /**
+     * Adds a given post to the feeds of all users who are subscribed to the topic of the post.
+     *
+     * @param post the post to be added to the feeds of subscribed users
+     */
+    public void addPostToFeeds(Post post) {
+        List<User> users = userRepository.findBySubscribedTopicsContaining(post.getTopic());
+        for (User user : users) {
+            user.getFeed().add(post);
+            userRepository.save(user);
+        }
+        log.info("Post added to feeds of subscribed users");
     }
 
 }

--- a/front/src/app/core/interfaces/user.interface.ts
+++ b/front/src/app/core/interfaces/user.interface.ts
@@ -2,8 +2,6 @@ export interface User {
   id?: number;
   email: string;
   userName: string;
-  password?: string;
-  subscriptions?: number[];
   createdAt?: Date;
   updatedAt?: Date;
 }


### PR DESCRIPTION
Introduce user feed handling to include posts in the feeds of users subscribed to the respective topics. Update UserDto and UserMapper to accommodate the new feed property. Implement logic to add posts to user feeds upon creation.